### PR TITLE
Correcting the run command for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Pull the image and run the container
 
 * `docker pull coreelec/coreelec-builder:latest`
-* `docker run -v ~/:/home/docker -h coreelec -it coreelec-builder`
+* `docker run -v ~/:/home/docker -h coreelec -it coreelec/coreelec-builder:latest`
 
 ## Clone repo and build image inside container
 


### PR DESCRIPTION
In order to fix the following error:

```
$ sudo docker run -v ~/:/home/docker -h coreelec -it coreelec-builder
Unable to find image 'coreelec-builder:latest' locally
docker: Error response from daemon: pull access denied for coreelec-builder, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```