### PR TITLE
Correcting arm into aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@
 
 * `git clone git://github.com/CoreELEC/CoreELEC.git ~/CoreELEC`
 * `cd ~/CoreELEC`
-* `time(PROJECT=Amlogic-ng ARCH=arm make image)`  
+* `time(PROJECT=Amlogic-ng ARCH=aarch64 make image)`  
 Use `PROJECT=Amlogic` to build images for older S912 and S905/X/D devices


### PR DESCRIPTION
I've successfully built CoreELEC images with this Dockerfile, given the following changes:
 * We must rename arm into aarch64 in the invocation command, as this is now the valid name for the Linux config
 * We must correct one package, which does not understand aarch64 ARCH, and also broken in several other ways: https://github.com/CoreELEC/CoreELEC/pull/267 Hopefully the devs could pass these soon, so that we could have a great and up-to-date Dockerfile!